### PR TITLE
Get number of last projects from config

### DIFF
--- a/otter/funcs.py
+++ b/otter/funcs.py
@@ -19,7 +19,10 @@ from otter.util.date import *
 
 
 def choose_project_task_id(args):
-    limit = 9  # maybe from config
+    config = deserialize()
+    projects = config['projects']
+
+    limit = int(projects)
 
     records = query_records_most_recent(limit)
 
@@ -180,7 +183,7 @@ def sync(args):
     print("Done.")
 
 
-def login(args):
+def config(args):
     cfg = deserialize()
 
     url = input_default("URL", cfg['url'] if 'url' in cfg else None)
@@ -195,6 +198,16 @@ def login(args):
     odoo_db = input_select_list_default("Database", databases, cfg['db'] if 'db' in cfg else None)
     cfg['db'] = odoo_db
     serialize(cfg)
+
+    projects = input_default("Number of last projects", cfg['projects'] if 'projects' in cfg else 9)
+    cfg['projects'] = int(projects)
+    serialize(cfg)
+
+    print("Config successfully written")
+
+
+def login(args):
+    cfg = deserialize()
 
     username = input_default("Username", cfg['user'] if 'user' in cfg else None)
     cfg['user'] = username

--- a/otter/odoo/rest.py
+++ b/otter/odoo/rest.py
@@ -22,6 +22,21 @@ def login(url, db, username, password):
         print("ERROR DURING LOGIN")
         sys.exit(1)
 
+    # odooSession.setSessionId(response.getString("session_id"));
+    # odooSession.setUid(response.getInt("uid"));
+    # odooSession.setUserContext(response.getMap("user_context"));
+    # odooSession.setUsername(response.getString("username"));
+
+    # print(response.json()['result']['expiration_date'])
+    # print(response.json()['result']['expiration_reason'])
+    # print(response.json()['result']['user_context'])
+
+    # JSONObject
+    # kwargs = new
+    # JSONObject();
+    # kwargs.put("context", odooSession.getUserContext());
+    # params.put("kwargs", kwargs);
+
     uid = response.json()['result']['uid']
     session = response.cookies['session_id']
 

--- a/otter/otter.py
+++ b/otter/otter.py
@@ -55,9 +55,12 @@ def main_internal(argv):
     subcommand.add_argument('--date', nargs="?", const="YESTERDAY", default="YESTERDAY")
     subcommand.set_defaults(func=funcs.sync)
 
-    subcommand = commands.add_parser('login', help="Login to Odoo")
+    subcommand = commands.add_parser('config', help="Config connection to Odoo")
     subcommand.add_argument('--url')
     subcommand.add_argument('--database')
+    subcommand.set_defaults(func=funcs.config)
+
+    subcommand = commands.add_parser('login', help="Login to Odoo")
     subcommand.add_argument('--username')
     subcommand.add_argument('--password')
     subcommand.set_defaults(func=funcs.login)


### PR DESCRIPTION
The login step has been split up again into a config step for general
configuration, so that 'login' only requires entering a username and a
password anymore.

The config step now also allows (besides URL and DB) to configure the
number of the last projects to display.